### PR TITLE
Initial release feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ const { createAction, createReducer, createSelector } = createSlice(
   INITIAL_STATE,
 );
 
-export const add = createAction('add', (todo: string) => todo);
-export const complete = createAction('complete', (item: Item) => item);
-export const remove = createAction('remove', (todo: Item) => todo);
+export const add = createAction('added', (todo: string) => todo);
+export const complete = createAction('completed', (item: Item) => item);
+export const remove = createAction('removed', (todo: Item) => todo);
 
 type HandledActions = ActionCreatorMap<
   [typeof add, typeof complete, typeof remove]
@@ -93,7 +93,7 @@ If using TypeScript, the action creator returned will create action objects that
 ```ts
 const { createAction } = createSlice('todos', { items: [] });
 
-const add = createAction('add', (value: string) => value);
+const add = createAction('added', (value: string) => value);
 // `action` is typed as { payload: string, type 'todos/add' }
 const action = add('stuff');
 ```
@@ -117,7 +117,7 @@ There are two ways to create a reducer:
 Using the former is preferred, because `redux-slices` will internally optimize the slice's reducer to only call handlers when the corresponding action type matches. `redux-slices` makes this easier by including the `type` property on any action creator generated with [`createAction`](#createaction):
 
 ```js
-const add = createAction('add', (value) => value);
+const add = createAction('added', (value) => value);
 
 const reducer = createReducer({
   [add.type]: (state, { payload: value }) => ({
@@ -130,7 +130,7 @@ const reducer = createReducer({
 If using TypeScript, you can pass a type map of type => handler, and it will narrowly-type all handlers for you:
 
 ```ts
-const add = createAction('add', (value) => value);
+const add = createAction('added', (value) => value);
 
 const actions = {
   [add.type]: add;
@@ -152,7 +152,7 @@ There is also a convenience type, [`ActionCreatorMap`](#actioncreatormap), provi
 If using TypeScript, an additional typing utility is provided to narrowly-type all handlers based on the actions for the slice without incurring any additional runtime cost.
 
 ```ts
-const add = createAction('add', (value: string) => value);
+const add = createAction('added', (value: string) => value);
 
 type ActionHandlers = ActionCreatorMap<[typeof add]>;
 
@@ -169,7 +169,7 @@ The action handler typing for the is also not specific to the slice the reducer 
 ```ts
 import { reset } from './appSlice';
 ...
-const add = createAction('add', (value: string) => value);
+const add = createAction('added', (value: string) => value);
 
 type ActionHandlers = ActionCreatorMap<[typeof add, typeof reset]>;
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Manage slices of redux store in a concise, clear, and well-typed way
   - [Usage](#usage)
   - [API](#api)
     - [createSlice](#createslice)
+      - [Initial state typing](#initial-state-typing)
     - [createAction](#createaction)
     - [createReducer](#createreducer)
       - [ActionCreatorMap](#actioncreatormap)
@@ -64,10 +65,23 @@ export const getTodos = createSelector((slice) => slice.items);
 ### createSlice
 
 ```ts
-function createSlice(sliceName: string, initialState: object): Slice;
+function createSlice(sliceName: string, initialState?: object): Slice;
 ```
 
-Creates a slice of state based on the name and initial state passed, and returns a suite of utilities that allow construction of common redux implementation methods.
+Creates a slice of state based on the name and initial state passed, and returns a suite of utilities that allow construction of common redux implementation methods. If `initialState` is not passed, the slice will default to an empty object for its state.
+
+#### Initial state typing
+
+Clearly defining the contract of your Redux state is considered a best practice, and `redux-slices` leans into this by making the type of your state object inferred from the `initialState` value passed. However, there are some scenarios where you want more control over the typing:
+
+- You defined your initial state with `as const`, and you want the state typing to be wider
+- You have dynamic population of the state, and you start with an empty object
+
+In these cases, you can pass generics to `createSlice` to ensure this typing is respected:
+
+```ts
+const slice = createSlice<'name', { dynamic?: boolean }>('name', {});
+```
 
 ### createAction
 

--- a/__tests__/index.ts
+++ b/__tests__/index.ts
@@ -21,6 +21,14 @@ describe('redux-slices', () => {
       expect(slice.initialState).toBe(INITIAL_STATE);
     });
 
+    it('should create a `Slice` without requiring an initial state', () => {
+      const slice = createSlice<'slice', { optional?: any[] }>('slice');
+
+      expect(slice).toBeInstanceOf(Slice);
+      expect(slice.name).toBe('slice');
+      expect(slice.initialState).toEqual({});
+    });
+
     it('should allow for building a slice with action creators, selectors, and a reducer', () => {
       const { createAction, createReducer, createSelector } = createSlice(
         'slice',

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
     "url": "https://github.com/planttheidea/redux-slices/issues"
   },
   "description": "Manage slices of a redux store in a concise, clear way",
-  "dependencies": {
-    "ts-toolbelt": "9.6.0"
-  },
   "devDependencies": {
     "@babel/cli": "7.15.7",
     "@babel/core": "7.15.8",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ export type { ActionCreatorMap } from './internalTypes';
  */
 export function createSlice<Name extends string, InitialState extends AnyState>(
   name: Name,
-  initialState: InitialState,
+  initialState?: InitialState,
 ) {
   return new Slice(name, initialState);
 }

--- a/src/internalTypes.ts
+++ b/src/internalTypes.ts
@@ -1,8 +1,19 @@
 import type { Reducer as ReduxReducer } from 'redux';
-import type { Tuple } from 'ts-toolbelt';
 
 export type AnyState = { [key: string]: any };
 export type Simplify<Type> = { [Key in keyof Type]: Type[Key] };
+
+// Implementation and supporting types taken from `ts-toolbelt` Tuple.List
+type Has<U, U1> = [U1] extends [U] ? 1 : 0;
+type List<Value = any> = ReadonlyArray<Value>;
+type Longest<L extends List, L1 extends List> = L extends unknown
+  ? L1 extends unknown
+    ? {
+        0: L1;
+        1: L;
+      }[Has<keyof L, keyof L1>]
+    : never
+  : never;
 
 type FluxStandardAction<Type, Payload, Meta> = Payload extends undefined
   ? Meta extends undefined
@@ -23,10 +34,7 @@ export type ActionCreator<
 > = PayloadCreator extends (...args: any[]) => any
   ? MetaCreator extends (...args: any[]) => any
     ? (
-        ...args: Tuple.Longest<
-          Parameters<PayloadCreator>,
-          Parameters<MetaCreator>
-        >
+        ...args: Longest<Parameters<PayloadCreator>, Parameters<MetaCreator>>
       ) => FluxStandardAction<
         Type,
         ReturnType<PayloadCreator>,


### PR DESCRIPTION
## Reason for change

I received some initial feedback related to the implementation, and also saw an opportunity to eliminate the one dependency from initial release.

## Change

- Surface the optional `initialState` (which was always supported, but masked by the `createSlice` wrapper)
- Provide documentation about customizing the typing of the state object via `createSlice`
- Modify example action types to be past tense, following [Redux action type naming best practices](https://redux.js.org/style-guide/style-guide#model-actions-as-events-not-setters)
- Remove `ts-toolbelt` dependency, which was only used for a single type utility